### PR TITLE
#35 - Migrate Spring Boot 3.4.3 to 3.5.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.3</version>
+        <version>3.5.11</version>
         <relativePath/>
     </parent>
     <groupId>com.bluestaq</groupId>


### PR DESCRIPTION
## What this PR does
- Updated spring-boot-starter-parent from 3.4.3 to 3.5.11
- Spring Boot 3.4.x has reached end of open source support
- Reviewed 3.5.x release notes — no breaking changes affecting
  our core stack of JPA, PostgreSQL, or validation
- All 13 tests passing with zero failures
- Application boots cleanly and connects to PostgreSQL
- All four endpoints verified manually with curl

## Migration Notes
Spring Boot 3.5.11 is the latest stable 3.5.x release as of
February 2026. This migration keeps the project current and
off the end-of-life 3.4.x line. No code changes were required
beyond the version bump in pom.xml.

Closes #35