### PR TITLE
#36 - Migrate Spring Boot 4.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.11</version>
+        <version>4.0.3</version>
         <relativePath/>
     </parent>
     <groupId>com.bluestaq</groupId>
@@ -55,6 +55,11 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webmvc-test</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
     <build>

--- a/src/test/java/com/bluestaq/notesvault/NoteControllerTest.java
+++ b/src/test/java/com/bluestaq/notesvault/NoteControllerTest.java
@@ -5,13 +5,11 @@ import com.bluestaq.notesvault.repository.NoteRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-
 import java.util.UUID;
-
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 


### PR DESCRIPTION
## What this PR does
- Updated spring-boot-starter-parent from 3.5.11 to 4.0.3
- Added spring-boot-starter-webmvc-test dependency for
  modularized test infrastructure in Spring Boot 4.x
- Updated AutoConfigureMockMvc import to new package
  org.springframework.boot.webmvc.test.autoconfigure
- All 13 tests passing with zero failures
- Application boots cleanly and connects to PostgreSQL
- All four endpoints verified manually with curl
- Validation and exception handling verified working

## Migration Notes
Spring Boot 4.0.3 introduced a modularized auto-configuration
architecture which required updating the test infrastructure.
The key change was moving AutoConfigureMockMvc to a new package
and adding the webmvc test starter. No business logic changes
were required. Migration path followed: 3.4.3 → 3.5.11 → 4.0.3

Closes #36