### PR TITLE
#20 - Health Checks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,72 +2,104 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
         <version>4.0.3</version>
         <relativePath/>
     </parent>
+
     <groupId>com.bluestaq</groupId>
     <artifactId>notes-vault</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <name>notes-vault</name>
     <description>Notes Vault API</description>
+
     <properties>
         <java.version>21</java.version>
     </properties>
+
     <dependencies>
-        <!-- Web -->
+
+        <!-- ==================== Core ==================== -->
+
+        <!-- Spring MVC web layer, REST controllers, embedded Tomcat -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
-        <!-- JPA -->
+
+        <!-- Spring Data JPA, Hibernate ORM, entity/repository support -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
-        <!-- PostgreSQL -->
+
+        <!-- Bean validation (@NotBlank, @Size, @Valid) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <!-- Actuator health and metrics endpoints (/actuator/health) -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
+        <!-- ==================== Database ==================== -->
+
+        <!-- PostgreSQL JDBC driver (runtime only, not needed at compile time) -->
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <scope>runtime</scope>
         </dependency>
-        <!-- H2 in-memory database for testing -->
-        <dependency>
-            <groupId>com.h2database</groupId>
-            <artifactId>h2</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <!-- Testing -->
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <!-- Spring DevTools -->
+
+        <!-- ==================== Development ==================== -->
+
+        <!-- DevTools: auto-restart and live reload during local development -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>
             <scope>runtime</scope>
             <optional>true</optional>
         </dependency>
+
+        <!-- ==================== Testing ==================== -->
+
+        <!-- H2 in-memory database used in place of PostgreSQL during tests -->
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Core test framework: JUnit 5, Mockito, AssertJ -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-validation</artifactId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
         </dependency>
+
+        <!-- Spring Boot 4.x modularized MockMvc test infrastructure -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webmvc-test</artifactId>
             <scope>test</scope>
         </dependency>
+
     </dependencies>
+
     <build>
         <plugins>
+            <!-- Packages the application as an executable JAR -->
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>
+
 </project>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,3 +9,7 @@ spring.datasource.driver-class-name=org.postgresql.Driver
 # JPA / Hibernate Configuration
 spring.jpa.hibernate.ddl-auto=${SPRING_JPA_HIBERNATE_DDL_AUTO:update}
 spring.jpa.show-sql=true
+
+# Health Checks
+management.endpoints.web.exposure.include=health
+management.endpoint.health.show-details=always


### PR DESCRIPTION
## What this PR does
- Added spring-boot-starter-actuator dependency to pom.xml
- Exposed /actuator/health endpoint via application.properties
- Health endpoint reports status of application and database connection
- Cleaned up and commented all pom.xml dependencies with section headers

## Verified
- GET http://localhost:8080/actuator/health returns 200 with status UP
- Database connectivity confirmed via db component in health response

Closes #20