### PR TITLE
#15 - Add PUT /notes/{id} endpoint

### DIFF
--- a/src/main/java/com/bluestaq/notesvault/controller/NoteController.java
+++ b/src/main/java/com/bluestaq/notesvault/controller/NoteController.java
@@ -52,4 +52,13 @@ public class NoteController {
         noteService.deleteNote(id);
         return ResponseEntity.noContent().build();
     }
+
+    // PUT /notes/{id} — updates an existing note, returns 200 OK or 404
+    @PutMapping("/{id}")
+    public ResponseEntity<Note> updateNote(
+            @PathVariable UUID id,
+            @Valid @RequestBody Note note) {
+        Note updated = noteService.updateNote(id, note);
+        return ResponseEntity.ok(updated);
+    }
 }

--- a/src/main/java/com/bluestaq/notesvault/service/NoteService.java
+++ b/src/main/java/com/bluestaq/notesvault/service/NoteService.java
@@ -46,4 +46,13 @@ public class NoteService {
         }
         noteRepository.deleteById(id);
     }
+
+    // Updates an existing note by ID — throws NoteNotFoundException if not found
+    public Note updateNote(UUID id, Note updatedNote) {
+        Note existing = noteRepository.findById(id)
+                .orElseThrow(() -> new NoteNotFoundException(
+                        "Note not found with id: " + id));
+        existing.setContent(updatedNote.getContent());
+        return noteRepository.save(existing);
+    }
 }

--- a/src/test/java/com/bluestaq/notesvault/NoteControllerTest.java
+++ b/src/test/java/com/bluestaq/notesvault/NoteControllerTest.java
@@ -1,7 +1,14 @@
 package com.bluestaq.notesvault;
 
-import com.bluestaq.notesvault.model.Note;
-import com.bluestaq.notesvault.repository.NoteRepository;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.UUID;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,9 +16,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import java.util.UUID;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.bluestaq.notesvault.model.Note;
+import com.bluestaq.notesvault.repository.NoteRepository;
 
 /**
  * API level tests for NoteController.
@@ -110,6 +117,34 @@ class NoteControllerTest {
     @Test
     void deleteNote_notFound_shouldReturn404() throws Exception {
         mockMvc.perform(delete("/notes/" + UUID.randomUUID()))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.status").value(404));
+    }
+
+    // PUT /notes/{id} — valid ID should return 200 OK with updated content
+    @Test
+    void updateNote_shouldReturn200() throws Exception {
+        Note note = new Note();
+        note.setContent("Original content");
+        Note saved = noteRepository.save(note);
+
+        String body = "{\"content\": \"Updated content\"}";
+
+        mockMvc.perform(put("/notes/" + saved.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").value("Updated content"));
+    }
+
+    // PUT /notes/{id} — non-existent ID should return 404 Not Found
+    @Test
+    void updateNote_notFound_shouldReturn404() throws Exception {
+        String body = "{\"content\": \"Updated content\"}";
+
+        mockMvc.perform(put("/notes/" + UUID.randomUUID())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.status").value(404));
     }

--- a/src/test/java/com/bluestaq/notesvault/NoteServiceTest.java
+++ b/src/test/java/com/bluestaq/notesvault/NoteServiceTest.java
@@ -1,21 +1,30 @@
 package com.bluestaq.notesvault;
 
-import com.bluestaq.notesvault.exception.NoteNotFoundException;
-import com.bluestaq.notesvault.model.Note;
-import com.bluestaq.notesvault.repository.NoteRepository;
-import com.bluestaq.notesvault.service.NoteService;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-
-import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import com.bluestaq.notesvault.exception.NoteNotFoundException;
+import com.bluestaq.notesvault.model.Note;
+import com.bluestaq.notesvault.repository.NoteRepository;
+import com.bluestaq.notesvault.service.NoteService;
 
 /**
  * Service layer tests for NoteService.
@@ -119,5 +128,41 @@ class NoteServiceTest {
                 () -> noteService.deleteNote(id));
         verify(noteRepository, times(1)).existsById(id);
         verify(noteRepository, never()).deleteById(id);
+    }
+
+    // updateNote — should update content and return the updated note
+    @Test
+    void updateNote_shouldUpdateAndReturnNote() {
+        UUID id = UUID.randomUUID();
+        Note existing = new Note();
+        existing.setContent("Original content");
+
+        Note updatedNote = new Note();
+        updatedNote.setContent("Updated content");
+
+        when(noteRepository.findById(id)).thenReturn(Optional.of(existing));
+        when(noteRepository.save(existing)).thenReturn(existing);
+
+        Note result = noteService.updateNote(id, updatedNote);
+
+        assertNotNull(result);
+        assertEquals("Updated content", result.getContent());
+        verify(noteRepository, times(1)).findById(id);
+        verify(noteRepository, times(1)).save(existing);
+    }
+
+    // updateNote — should throw NoteNotFoundException when note does not exist
+    @Test
+    void updateNote_shouldThrowExceptionWhenNotFound() {
+        UUID id = UUID.randomUUID();
+        Note updatedNote = new Note();
+        updatedNote.setContent("Updated content");
+
+        when(noteRepository.findById(id)).thenReturn(Optional.empty());
+
+        assertThrows(NoteNotFoundException.class,
+                () -> noteService.updateNote(id, updatedNote));
+        verify(noteRepository, times(1)).findById(id);
+        verify(noteRepository, never()).save(any());
     }
 }


### PR DESCRIPTION
## What this PR does
- Added updateNote method to NoteService
- Added PUT /notes/{id} endpoint to NoteController
- Returns 200 OK with updated note on success
- Returns 404 Not Found if note does not exist
- Validation applied via @Valid — returns 400 if content is blank or exceeds 500 characters
- Added 2 tests to NoteControllerTest (happy path and 404)
- Added 2 tests to NoteServiceTest (happy path and 404)
- All 17 tests passing with zero failures
- Verified manually via curl against running Docker containers

Closes #15